### PR TITLE
fix: Replace ghrc.io (malicious) with ghcr.io (correct)

### DIFF
--- a/scripts/ghcr-release
+++ b/scripts/ghcr-release
@@ -10,7 +10,7 @@ HERE="$(dirname "$(readlink -f "$0")")"
 }
 
 src_image="registry.code.rit.edu/its-operations-public/django-acmev2"
-dest_image="ghrc.io/rit-its/certificat"
+dest_image="ghcr.io/rit-its/certificat"
 
 docker pull "${src_image}:${1}"
 


### PR DESCRIPTION
The typo-squatted domain ghrc.io appears to be malicious, stealing authentication tokens when attempting to use it as an image registry.

The correct URL for the GitHub Container Registry is ghcr.io.

Source: https://bmitch.net/blog/2025-08-22-ghrc-appears-malicious/

Closes #3.