### PR TITLE
Fix CSRF vulnerability on edit_binding and use CSPRNG for HMAC key generation

### DIFF
--- a/src/certificat/modules/acme/models.py
+++ b/src/certificat/modules/acme/models.py
@@ -1,6 +1,6 @@
 import json
 import operator
-import random
+import secrets
 import string
 from enum import Enum
 from typing import List, Mapping, Self
@@ -131,10 +131,10 @@ class AccountBinding(TimestampMixin):
 
         binding = AccountBinding(
             hmac_id="".join(
-                random.choices(cls.KID_ENTROPY, k=app_settings.hmac_id_length)
+                secrets.choice(cls.KID_ENTROPY) for _ in range(app_settings.hmac_id_length)
             ),
             hmac_key="".join(
-                random.choices(cls.HMAC_ENTROPY, k=app_settings.hmac_key_length)
+                secrets.choice(cls.HMAC_ENTROPY) for _ in range(app_settings.hmac_key_length)
             ),
             creator=creator,
             note=note,

--- a/src/certificat/modules/acme/util.py
+++ b/src/certificat/modules/acme/util.py
@@ -1,6 +1,7 @@
-import random
+import secrets
 import string
 
 
 def gen_id(length=10) -> str:
-    return "".join(random.choices(string.ascii_letters + string.digits, k=length))
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))

--- a/src/certificat/modules/api/views.py
+++ b/src/certificat/modules/api/views.py
@@ -10,7 +10,6 @@ from lxml_html_clean import Cleaner
 from certificat.modules.acme import models as db
 from django.db.models import Count, DateField
 from django.utils.dateformat import format
-from django.views.decorators.csrf import csrf_exempt
 from django.utils import timezone, dateparse
 from django.db.models import Func
 from django.views.decorators.cache import cache_page
@@ -64,7 +63,6 @@ def my_groups(request: HttpRequest):
 
 
 @login_required
-@csrf_exempt
 @require_http_methods(["POST"])
 def edit_binding(request: HttpRequest, binding_name):
     binding = get_object_or_404(

--- a/src/frontend/src/components/accountAccessManager.tsx
+++ b/src/frontend/src/components/accountAccessManager.tsx
@@ -1,7 +1,7 @@
 import { LitElement, html } from "lit";
 import { ref, createRef, Ref } from 'lit/directives/ref.js';
 import { customElement, property, state } from "lit/decorators.js";
-import { getErrorMessage } from "../util";
+import { getErrorMessage, getCsrfToken } from "../util";
 import { Task, TaskStatus } from "@lit/task";
 
 interface Group {
@@ -71,6 +71,7 @@ export class AccountAccessManagerElement extends LitElement {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
+                    "X-CSRFToken": getCsrfToken(),
                 },
                 body: JSON.stringify({
                     "groups": {

--- a/src/frontend/src/components/editableText.tsx
+++ b/src/frontend/src/components/editableText.tsx
@@ -1,6 +1,7 @@
 import { LitElement, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
+import { getCsrfToken } from "../util";
 
 @customElement("editable-text")
 export class EditableTextElement extends LitElement {
@@ -94,6 +95,7 @@ export class EditableTextElement extends LitElement {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
+                    "X-CSRFToken": getCsrfToken(),
                 },
                 body: JSON.stringify(body),
                 credentials: "same-origin",

--- a/src/frontend/src/util.ts
+++ b/src/frontend/src/util.ts
@@ -2,3 +2,8 @@ export function getErrorMessage(error: unknown) {
 	if (error instanceof Error) return error.message
 	return String(error)
 }
+
+export function getCsrfToken(): string {
+	const match = document.cookie.match(/(?:^|;\s*)csrftoken=([^\s;]+)/);
+	return match ? match[1] : "";
+}


### PR DESCRIPTION
Summary

  - Remove @csrf_exempt from edit_binding — This session-authenticated POST endpoint was vulnerable to CSRF. Frontend   components now send the Django CSRF token via X-CSRFToken header.
  - Replace random.choices() with secrets.choice() — HMAC IDs and keys for ACME External Account Binding were generated with the Mersenne Twister PRNG, which is not cryptographically secure. Switched to the secrets module (CSPRNG).

  Files changed (6)

  - src/certificat/modules/api/views.py — Removed @csrf_exempt decorator
  - src/certificat/modules/acme/models.py — random.choices → secrets.choice for HMAC key gen
  - src/certificat/modules/acme/util.py — random.choices → secrets.choice for gen_id()
  - src/frontend/src/util.ts — Added getCsrfToken() helper
  - src/frontend/src/components/editableText.tsx — Sends CSRF token on POST
  - src/frontend/src/components/accountAccessManager.tsx — Sends CSRF token on POST

  Test plan

  - Verify editing binding name/note still works in the UI
  - Verify adding/removing group scopes still works in the UI
  - Verify new account bindings generate valid HMAC credentials
  - Verify CSRF protection blocks cross-origin POST to /api/binding/